### PR TITLE
fix: better Oruga UI detection

### DIFF
--- a/detectors/uis.json
+++ b/detectors/uis.json
@@ -8,8 +8,8 @@
     },
     "detectors": {
       "js": [
-        "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__?.$oruga)).filter(Boolean).length",
-        "[...document.querySelectorAll('*')].filter((el) =>  ['o-autocomplete', 'o-button', 'o-checkbox ', 'o-collapse', 'o-dropdown', 'o-field', 'o-icon', 'o-input', 'o-loading', 'o-modal', 'o-pagination', 'o-radio', 'o-select', 'o-sidebar', 'o-skeleton', 'o-slider', 'o-steps', 'o-switch', 'o-table', 'o-tabs', 'o-tooltip', 'o-upload', 'o-carousel', 'o-dialog', 'o-clockpicker', 'o-datepicker', 'o-datimepicker', 'o-numberinput', 'o-timepicker', 'o-taginput', 'o-image', 'o-notification', 'o-navbar', 'o-menu', 'o-tag'].includes(el.__vue__?.$options?._componentTag)).length"
+        "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vue__?.$options.isOruga)).filter(Boolean).length",
+        "[...document.querySelectorAll('*')].map((el) => Boolean(el.__vueParentComponent?.ctx.$options.isOruga)).filter(Boolean).length"
       ]
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New Detector
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This PR changes the OrugaUI detection from release 0.3.x. Since a lot of website uses the "o-" prefix for their CSS classe without using OrugaUI at all, we prefer to act on javascript to detect OrugaUI adoption. 🐛

This PR detects OrugaUI both on Vue 2.x and 3.x (oruga-next package).

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the README accordingly <!-- apply to new detector or new feature -->
- [ ] I have added the icon of my detector in `icons/` <!-- apply to new detector -->
