### PR TITLE
feat: added vee-validate v4 detector

### DIFF
--- a/detectors/plugins.json
+++ b/detectors/plugins.json
@@ -108,7 +108,7 @@
       "url": "https://vee-validate.logaretm.com/"
     },
     "detectors": {
-      "js": "Boolean([...document.querySelectorAll('*')].find((el) => Boolean(el.__vue__ && ('$_veeObserver' in el.__vue__ || (el.__vue__.$validator && 'attach' in el.__vue__.$validator)))))"
+      "js": "window.VeeValidate || Boolean([...document.querySelectorAll('*')].find((el) => Boolean(el.__vue__ && ('$_veeObserver' in el.__vue__ || (el.__vue__.$validator && 'attach' in el.__vue__.$validator)) || el.__vueParentComponent && el.__vueParentComponent.provides && Reflect.ownKeys(el.__vueParentComponent.provides).some(i => /vee-validate/i.test(i.description)) )))"
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

- [x] New Detector
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

I added a set of conditions that apply to Vue 3 and detects the usage of vee-validate v4 which wasn't covered before.

I will explain the additional bits here:

```js
// Looks like vue 3 injects the context component as `__vueParentComponent`
el.__vueParentComponent;

// Check if that component has provided some injections
el.__vueParentComponent.provides 

// Check if any of these injections contain `vee-validate` in their description
// vee-validate v4 makes heavy use of provide/inject so it makes sense to look there
// Using Reflect.ownKeys because symbols do not appear in Object.keys ...
Reflect.ownKeys(el.__vueParentComponent.provides).some(i => /vee-validate/i.test(i.description))
```

I also added a:

```js
window.VeeValidate
```

To avoid iterating over all the elements if vee-validate is used via CDN or UMD bundle.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the README accordingly <!-- apply to new detector or new feature -->
- [ ] I have added the icon of my detector in `icons/` <!-- apply to new detector -->

> Nothing applies to the checklist in this PR