### PR TITLE
fix: add `@nuxtjs/color-mode` recognition case

### DIFF
--- a/detectors/nuxt.modules.json
+++ b/detectors/nuxt.modules.json
@@ -315,7 +315,7 @@
       "url": "https://color-mode.nuxtjs.org"
     },
     "detectors": {
-      "js": "window.$nuxt?.$options?.context?.app?.$colorMode || window.$nuxt?.$colorMode || (window.__NUXT__?.state && window.__NUXT__?.state['color-mode'])"
+      "js": "window.$nuxt?.$options?.context?.app?.$colorMode || window.$nuxt?.$colorMode || (window.__NUXT__?.state && window.__NUXT__?.state['color-mode']) || window.__NUXT_COLOR_MODE__ "
     }
   },
   "nuxt-ackee": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New Detector
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Not sure if this actually helps, but noticed on some of my newer projects that color-mode module wasn't properly recognized, so this PR should fix it considering that `window.__NUXT_COLOR_MODE__` exists in projects using it
